### PR TITLE
Fix AddToSlack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A bot for xwingtmg.slack.com.
 - Detects links to lists from <http://geordanr.github.io/xwing/>, <http://xwing-builder.co.uk/build> and <http://x-wing.fabpsb.net> and print them in chat
 - Card lookup via [[]] queries
 
-<a href="https://slack.com/oauth/authorize?scope=bot&client_id=22172116449.94722582676"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+<a href="https://beepboophq.com/api/slack/auth/add-to-slack/3d08ff85a092464d83b0063bead84537"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
 
 Written in CoffeeScript.
 


### PR DESCRIPTION
A user reached out to us at Beep Boop and was having problem adding your project to Slack via the button in the README. This fixes that with the link that redirects through Beep Boop first that knows where to redirect and knows what oauth scopes you are requesting and such.