### PR TITLE
Add Pathlib to requirements

### DIFF
--- a/icons/requirements.txt
+++ b/icons/requirements.txt
@@ -1,1 +1,2 @@
 Pillow
+Pathlib


### PR DESCRIPTION
I rarely use python so I was missing this package.