### PR TITLE
Add utf-8 encoding to stat_icons.py

### DIFF
--- a/icons/stat_icons.py
+++ b/icons/stat_icons.py
@@ -1,3 +1,4 @@
+#coding: utf-8
 import os
 
 from PIL import Image, ImageFont, ImageDraw, ImageOps, ImageFilter


### PR DESCRIPTION
Python complains about the presence of a non-ascii character without this line