### PR TITLE
removed slack formatting from URLs

### DIFF
--- a/r2d7/listformatter.py
+++ b/r2d7/listformatter.py
@@ -47,6 +47,7 @@ class ListFormatter(DroidCore):
             xws_url = f"https://launch-bay-next.herokuapp.com/xws?lbx={match[3]}"
 
         if xws_url:
+            xws_url = ListFormatter.clean_slack_formatting(xws_url)
             xws_url = unescape(xws_url)
             logging.info(f"Requesting {xws_url}")
             response = requests.get(xws_url)
@@ -145,3 +146,6 @@ class ListFormatter(DroidCore):
         if xws:
             return self.print_xws(xws, url=message)
         return []
+
+    def clean_slack_formatting(url):
+        return url.replace('&amp;','&').replace('&lt;','<').replace('&gt;','<')


### PR DESCRIPTION
slack is automatically converting & to &amp
From https://api.slack.com/docs/message-formatting, it appears to be doing the following to URLs:
    Replace the ampersand, &, with &amp;
    Replace the less-than sign, < with &lt;
    Replace the greater-than sign, > with &gt;

This PR converts URLs back to their old form.