### PR TITLE
Added fix for slack URL formatting on mobile

### DIFF
--- a/r2d7/core.py
+++ b/r2d7/core.py
@@ -75,6 +75,7 @@ class DroidCore():
     MANIFEST = 'data/manifest.json'
     # VERSION_RE = re.compile(r'xwing-data/releases/tag/([\d\.]+)')
     check_frequency = 900  # 15 minutes
+    formatted_link_regex = re.compile(r'(?P<url>http(s)?://.*?)\|(?P<text>.*)')
 
     @classmethod
     def get_file(cls, filepath):

--- a/r2d7/listformatter.py
+++ b/r2d7/listformatter.py
@@ -47,7 +47,6 @@ class ListFormatter(DroidCore):
             xws_url = f"https://launch-bay-next.herokuapp.com/xws?lbx={match[3]}"
 
         if xws_url:
-            xws_url = ListFormatter.clean_slack_formatting(xws_url)
             xws_url = unescape(xws_url)
             logging.info(f"Requesting {xws_url}")
             response = requests.get(xws_url)
@@ -141,11 +140,12 @@ class ListFormatter(DroidCore):
         return [output]
 
     def handle_url(self, message):
+        match = self.formatted_link_regex.match(message)
+        if match:
+            message = match['url']
         xws = self.get_xws(message)
         logger.debug(xws)
         if xws:
             return self.print_xws(xws, url=message)
         return []
 
-    def clean_slack_formatting(url):
-        return url.replace('&amp;','&').replace('&lt;','<').replace('&gt;','<')

--- a/tests/test_listformatter.py
+++ b/tests/test_listformatter.py
@@ -22,7 +22,7 @@ get_xws_tests = (
     ),
     (
         "https://launch-bay-next.herokuapp.com/print?lbx=%27New%20Squadron%27.34.3.0.(44.188.(3.256))&mode=full",
-        {"name": "New Squadron", "faction": "scumandvillainy", "pilots": [{"ship": "m3ainterceptor", "upgrades": {"cannon": ["heavylasercannon"]}, "id":"sunnybounder"}], "version": "2.0.0", "points": 34, "vendor": {
+        {"name": "New Squadron", "description": "", "faction": "scumandvillainy", "pilots": [{"ship": "m3ainterceptor", "upgrades": {"cannon": ["heavylasercannon"]}, "id":"sunnybounder", "points": 34}], "version": "2.0.0", "points": 34, "vendor": {
             "lbn": {"builder": "Launch Bay Next", "builder_url": "https://launch-bay-next.herokuapp.com", "link": "https://launch-bay-next.herokuapp.com/print?lbx='New%20Squadron'.34.3.0.(44.188.(3.256))"}}},
     ),
 )


### PR DESCRIPTION
Slack now treats links in mobile messages like links in bot messages,
converting them to the format '<original_url|escaped_url>'. Users can
only see the text (right side) but r2-d7 passes both through to message
handlers as 'original_url|escaped_url'. It is the message handler's
responsibility to parse this as needed