### PR TITLE
Split list formatter into smaller methods

### DIFF
--- a/r2d7/listformatter.py
+++ b/r2d7/listformatter.py
@@ -135,7 +135,7 @@ class ListFormatter(DroidCore):
 
                 upgrade_text = self.wiki_link(upgrade['name'])
                 upgrades.append(upgrade_text)
-                points+=self.get_upgrade_cost(pilot_card, upgrade)
+                points += self.get_upgrade_cost(pilot_card, upgrade)
 
             ship_line = (
                 self.iconify(pilot_card['ship']['name']) +
@@ -161,4 +161,3 @@ class ListFormatter(DroidCore):
         if xws:
             return self.print_xws(xws, url=message)
         return []
-


### PR DESCRIPTION
Split list formatter into smaller methods

This is a safe refactor before making more changes. My real goal is to change the links so they point to the right pilot in cases of same pilot name being for multiple ships (e.g. Anakin). I was first splitting this into smaller methods to understand the code