### PR TITLE
Added prompt for user to delete their message

### DIFF
--- a/r2d7/discord/__main__.py
+++ b/r2d7/discord/__main__.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import re
+import asyncio
 
 import discord
 

--- a/r2d7/discord/__main__.py
+++ b/r2d7/discord/__main__.py
@@ -82,6 +82,28 @@ class DiscordClient(discord.Client):
                         current_message = fixed_line
                 await message.channel.send(
                     embed=discord.Embed(description=current_message))
+                
+            if message.guild.me.permissions_in(message.channel).manage_messages:
+                prompt_delete_previous_message = await message.channel.send("Delete your message?")
+                await prompt_delete_previous_message.add_reaction("✅")
+                await prompt_delete_previous_message.add_reaction("❌")
+
+                try:
+                    reaction, user = await self.wait_for(
+                        event="reaction_add",
+                        timeout=10,
+                        check=lambda reaction, user: user == message.author
+                    )
+                    if str(reaction.emoji) == "✅":
+                        await message.delete()
+                        await prompt_delete_previous_message.delete()
+                        return
+                    if str(reaction.emoji) == "❌":
+                        await prompt_delete_previous_message.delete()
+                        return
+                except asyncio.TimeoutError:
+                    await prompt_delete_previous_message.delete()
+                    return
 
 
 def main():

--- a/r2d7/discord/__main__.py
+++ b/r2d7/discord/__main__.py
@@ -2,7 +2,6 @@
 import logging
 import os
 import re
-import asyncio
 
 import discord
 
@@ -78,33 +77,12 @@ class DiscordClient(discord.Client):
                     if len(current_message) + 2 + len(fixed_line) < 2048:
                         current_message += f"\n{fixed_line}"
                     else:
-                        await message.channel.send(
-                            embed=discord.Embed(description=current_message))
+                        embed=discord.Embed(description=current_message)
+                        embed.set_footer(text=f"*Requested by {message.author.mention}*")
+                        await message.channel.send(embed=embed)
                         current_message = fixed_line
                 await message.channel.send(
-                    embed=discord.Embed(description=current_message))
-                
-            if message.guild.me.permissions_in(message.channel).manage_messages:
-                prompt_delete_previous_message = await message.channel.send("Delete your message?")
-                await prompt_delete_previous_message.add_reaction("✅")
-                await prompt_delete_previous_message.add_reaction("❌")
-
-                try:
-                    reaction, user = await self.wait_for(
-                        event="reaction_add",
-                        timeout=10,
-                        check=lambda reaction, user: user == message.author
-                    )
-                    if str(reaction.emoji) == "✅":
-                        await message.delete()
-                        await prompt_delete_previous_message.delete()
-                        return
-                    if str(reaction.emoji) == "❌":
-                        await prompt_delete_previous_message.delete()
-                        return
-                except asyncio.TimeoutError:
-                    await prompt_delete_previous_message.delete()
-                    return
+                    embed=discord.Embed(description=current_message))            
 
 
 def main():


### PR DESCRIPTION
When a user triggers a response from the bot, a short prompt pops up ("delete your message?") and attaches 2 emojis to itself (check mark / X). If the original user clicks the check mark, both the prompt and the trigger message get deleted. If the X is clicked, or 10 seconds elapse, the prompt gets deleted. As of the moment, this is untested in Slack, and if the original user adds an unaccounted-for emoji, nothing happens (but the message now cannot be deleted).