### PR TITLE
Increase embed limit to 3952 to prevent splitting of lists in most cases

### DIFF
--- a/r2d7/discord/__main__.py
+++ b/r2d7/discord/__main__.py
@@ -127,7 +127,8 @@ class DiscordClient(discord.Client):
                     for slack_style, discord_style in emoji_map.items():
                         fixed_line = fixed_line.replace(
                             slack_style, discord_style)
-                    if len(current_message) + 2 + len(fixed_line) < 2048:
+                    # Set maximum size for embed to maximum content size of embed minus the maximum for footer
+                    if len(current_message) + 2 + len(fixed_line) < 3952:
                         current_message += f"\n{fixed_line}"
                     else:
                         embed = discord.Embed(description=current_message)


### PR DESCRIPTION
This PR increases the pagination limit for embeds to 3952 characters as that is the current safe limit for descriptions in the Discord API. The maximum size for an Embed being 6000 and the maximum size for the footer being 2048 characters.

https://discord.com/developers/docs/resources/channel#embed-object-embed-limits