### PR TITLE
Fixes URL errors with left-right quotation marks in card titles

### DIFF
--- a/r2d7/slackdroid.py
+++ b/r2d7/slackdroid.py
@@ -177,6 +177,7 @@ You can also search for cards by points value in a particular slot. Eg. `[[:crew
             fudged_name += '_(VCX-100)'
         elif re.match(r'"Heavy_Scyk"_Interceptor', fudged_name):
             fudged_name = '"Heavy_Scyk"_Interceptor'
+        fudged_name = fudged_name.replace('“', '').replace('”', '')
         fudged_name = quote(fudged_name)
         url = f"https://xwingtmgwiki.com/{fudged_name}"
         return cls.link(url, card_name)


### PR DESCRIPTION
Left-right quotation marks (retrieved from data from xwing-data2) are now removed from wiki links.